### PR TITLE
Disable SSL verification

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -14,7 +14,7 @@ module.exports = settings => {
     next();
   });
 
-  app.use(proxy({ target: settings.api }));
+  app.use(proxy({ target: settings.api, secure: false }));
 
   return app;
 


### PR DESCRIPTION
The non-internet-facing services use self-signed certificates, so we need to disable SSL verification or the proxy doesn't work.