### PR TITLE
Add `npm audit` step to build pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,14 +1,25 @@
 pipeline:
 
   test:
-    image: node:8
+    image: node:10
     secrets:
       - npm_auth_token
     commands:
-      - npm install
+      - npm ci
       - npm test
     when:
       event: [push, pull_request, tag]
+
+  audit:
+    image: node:10
+    secrets:
+      - npm_auth_token
+    commands:
+      - npx @lennym/ciaudit
+    when:
+      event:
+        - push
+        - pull_request
 
   build:
     image: docker:17.09.1


### PR DESCRIPTION
Also cleans up test step by using node@10 and `npm ci` instead of install.