### PR TITLE
Include non-active projects in count

### DIFF
--- a/lib/routers/search/project.js
+++ b/lib/routers/search/project.js
@@ -5,7 +5,7 @@ module.exports = () => {
   const router = Router({ mergeParams: true });
 
   const count = (Project) => {
-    return Project.query().where({ status: 'active' }).count().then(result => result[0].count);
+    return Project.query().count().then(result => result[0].count);
   };
 
   const searchAndFilter = (Project, {


### PR DESCRIPTION
This was removed from the query, but not from the count so now it says:

> Showing 1068 of 990 results