### PR TITLE
Use error handler

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -7,6 +7,8 @@ const user = require('./middleware/user');
 const profile = require('./routers/profile');
 const searchRouter = require('./routers/search');
 
+const errorHandler = require('./error-handler');
+
 module.exports = settings => {
 
   const app = api(settings);
@@ -50,6 +52,8 @@ module.exports = settings => {
     }
     next();
   });
+
+  app.use(errorHandler(settings));
 
   app.use(proxy(settings.api));
 

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,7 +1,9 @@
 module.exports = () => {
 
   return (error, req, res, next) => {
-    console.error(error);
+    if (error.status > 499) {
+      console.error(error);
+    }
     res.status(error.status || 500);
     res.json({ message: error.message });
   };


### PR DESCRIPTION
There was an error handler middleware defined, but it wasn't being used, which meant that clients got a gnarly JSON parsing error rather than the actual error.