### PR TITLE
Add error handler to proxy middleware

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -7,7 +7,7 @@ module.exports = target => {
 
   return (req, res, next) => {
     const buffer = req._body && streamify(JSON.stringify(req.body));
-    proxy.web(req, res, { target, buffer, secure: false });
+    proxy.web(req, res, { target, buffer, secure: false }, err => next(err));
   };
 
 };


### PR DESCRIPTION
Handle error connecting to downstream service in proxy middleware. Currently an error connecting downstream crashes the entire service instead of just the request.