### PR TITLE
Use req.log for logging errors

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,8 +1,8 @@
 module.exports = () => {
 
   return (error, req, res, next) => {
-    if (error.status > 499) {
-      console.error(error);
+    if (error.status > 499 && typeof req.log === 'function') {
+      req.log('error', error);
     }
     res.status(error.status || 500);
     res.json({ message: error.message });


### PR DESCRIPTION
This means it will use winston logger, which can be configured to pass JSON log formats instead of strings, which in turn makes using kibana to read logs in ACP _a lot_ nicer.