### PR TITLE
Ensure all errors are logged correctly

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -53,9 +53,9 @@ module.exports = settings => {
     next();
   });
 
-  app.use(errorHandler(settings));
-
   app.use(proxy(settings.api));
+
+  app.use(errorHandler(settings));
 
   return app;
 

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,10 +1,11 @@
 module.exports = () => {
 
   return (error, req, res, next) => {
-    if (error.status > 499 && typeof req.log === 'function') {
+    error.status = error.status || 500;
+    if (error.status > 499) {
       req.log('error', error);
     }
-    res.status(error.status || 500);
+    res.status(error.status);
     res.json({ message: error.message });
   };
 


### PR DESCRIPTION
* Move the error handler to below the proxy, so that it can handle proxy errors.
* Default the error status before checking it in the error handelr so that errors with no statuses (most unhandled ones) are logged.