### PR TITLE
Modify host header when proxying to public ui

### DIFF
--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -7,7 +7,7 @@ module.exports = target => {
 
   return (req, res, next) => {
     const buffer = req._body && streamify(JSON.stringify(req.body));
-    proxy.web(req, res, { target, buffer, secure: false }, err => next(err));
+    proxy.web(req, res, { target, buffer, secure: false, changeOrigin: true }, err => next(err));
   };
 
 };


### PR DESCRIPTION
Where API services have been made public then the host header for the proxied request needs to match that configured on the ingress as the url for the service. Otherwise the proxied request is redirected back to the source service on account of its host header, and it throws into an infinite loop.