### PR TITLE
Allow search by email addresses

### DIFF
--- a/lib/routers/search/profile.js
+++ b/lib/routers/search/profile.js
@@ -23,6 +23,7 @@ module.exports = () => {
       .where(builder => {
         if (search) {
           return builder
+            .where('email', 'iLike', `%${search}%`)
             .orWhere(builder => Profile.searchFullName({ search, query: builder }));
         }
       });


### PR DESCRIPTION
As well as matching the name, allow ASRU users to search by partial email address when finding profiles.