### PR TITLE
Proxy metrics endpoints from workflow

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -25,6 +25,8 @@ module.exports = settings => {
 
   app.use(user());
 
+  app.use('/metrics', proxy(`${settings.workflow}/metrics`));
+
   app.use('/asru', asruEstablishment());
 
   app.use('/profile', profile());


### PR DESCRIPTION
Allows the UI to make requests directly to the metrics router on workflow.