### PR TITLE
Apply unsubmitted drafts filter to projects

### DIFF
--- a/lib/routers/search/project.js
+++ b/lib/routers/search/project.js
@@ -5,7 +5,7 @@ module.exports = () => {
   const router = Router({ mergeParams: true });
 
   const count = (Project) => {
-    return Project.query().count().then(result => result[0].count);
+    return Project.filterUnsubmittedDrafts(Project.query().count()).then(result => result[0].count);
   };
 
   const searchAndFilter = (Project, {
@@ -28,6 +28,8 @@ module.exports = () => {
             .orWhere('projects.licenceNumber', 'iLike', `%${search}%`);
         }
       });
+
+    query = Project.filterUnsubmittedDrafts(query);
 
     query = Project.paginate({ query, limit, offset });
 


### PR DESCRIPTION
On a user's profile and on project search, ensure that the database query to find projects includes an unsubmitted drafts filter.