### PR TITLE
Refactor project search count function to not count multiple projects

### DIFF
--- a/lib/routers/search/project.js
+++ b/lib/routers/search/project.js
@@ -4,8 +4,9 @@ module.exports = () => {
 
   const router = Router({ mergeParams: true });
 
-  const count = (Project) => {
-    return Project.filterUnsubmittedDrafts(Project.query().count()).then(result => result[0].count);
+  const count = Project => {
+    return Project.filterUnsubmittedDrafts(Project.query().distinct('projects.id'))
+      .then(results => results.length);
   };
 
   const searchAndFilter = (Project, {


### PR DESCRIPTION
Because `filterSubmittedDrafts` does a `joinRelation` with project versions it was counting some projects twice and so the total number of projects was returning incorrectly.

Add a distinct clause to ensure every project is included only once.