### PR TITLE
Ensure counts are always returned to the client as integers

### DIFF
--- a/lib/routers/search/establishment.js
+++ b/lib/routers/search/establishment.js
@@ -5,7 +5,7 @@ module.exports = () => {
   const router = Router({ mergeParams: true });
 
   const count = (Establishment) => {
-    return Establishment.query().count().then(result => result[0].count);
+    return Establishment.query().count().then(result => parseInt(result[0].count, 10));
   };
 
   const searchAndFilter = (Establishment, {

--- a/lib/routers/search/profile.js
+++ b/lib/routers/search/profile.js
@@ -5,7 +5,7 @@ module.exports = () => {
   const router = Router({ mergeParams: true });
 
   const count = (Profile) => {
-    return Profile.query().count().then(result => result[0].count);
+    return Profile.query().count().then(result => parseInt(result[0].count, 10));
   };
 
   const searchAndFilter = (Profile, {


### PR DESCRIPTION
Sometimes they're coming back as integers and sometimes as strings. Make sure they're always integers.