### PR TITLE
Ensure projects are distinct on profile endpoint

### DIFF
--- a/lib/routers/profile.js
+++ b/lib/routers/profile.js
@@ -51,7 +51,10 @@ module.exports = () => {
         req.profile = profile;
       })
       .then(() => {
-        return Project.filterUnsubmittedDrafts(Project.query().where({ licenceHolderId: req.profile.id }));
+        const query = Project.query()
+          .distinct('projects.*')
+          .where({ licenceHolderId: req.profile.id });
+        return Project.filterUnsubmittedDrafts(query);
       })
       .then(projects => {
         req.profile.projects = projects;


### PR DESCRIPTION
Prevents bug where a project with several versions appears multiple times on a user's profile.