### PR TITLE
Move waiver routes to top of router

### DIFF
--- a/lib/routers/billing.js
+++ b/lib/routers/billing.js
@@ -54,6 +54,30 @@ module.exports = () => {
 
   app.use(permissions('licenceFees'));
 
+  app.get('/waiver',
+    permissions('pil.updateBillable'),
+    (req, res, next) => {
+      const { FeeWaiver } = req.models;
+      const { establishmentId, pilId } = req.query;
+      const year = parseInt(req.query.year, 10);
+      return FeeWaiver
+        .query()
+        .findOne({ establishmentId, pilId, year })
+        .eager('waivedBy')
+        .then(result => {
+          res.response = result;
+          next('router');
+        })
+        .catch(next);
+    }
+  );
+
+  app.post('/waiver',
+    permissions('pil.updateBillable'),
+    update(),
+    (req, res, next) => next('router')
+  );
+
   app.use((req, res, next) => {
     let year = req.query.year;
     if (!year) {
@@ -147,29 +171,6 @@ module.exports = () => {
       .catch(next);
 
   });
-
-  app.get('/waiver',
-    permissions('pil.updateBillable'),
-    (req, res, next) => {
-      const { FeeWaiver } = req.models;
-      const { establishmentId, pilId } = req.query;
-      const year = parseInt(req.query.year, 10);
-      return FeeWaiver
-        .query()
-        .findOne({ establishmentId, pilId, year })
-        .eager('waivedBy')
-        .then(result => {
-          res.response = result;
-          next();
-        })
-        .catch(next);
-    }
-  );
-
-  app.post('/waiver',
-    permissions('pil.updateBillable'),
-    update()
-  );
 
   return app;
 };


### PR DESCRIPTION
These don't need to do any of the additional queries to load data so move them to the top and exit early when they're hit.