### PR TITLE
Make previous years licence fees the default

### DIFF
--- a/lib/routers/billing.js
+++ b/lib/routers/billing.js
@@ -4,6 +4,14 @@ const { NotFoundError } = require('@asl/service/errors');
 const permissions = require('@asl/service/lib/middleware/permissions');
 const { fees } = require('@asl/constants');
 
+const getDefaultYear = () => {
+  const lastYear = (new Date()).getFullYear() - 1;
+  if (Object.keys(fees).includes(lastYear.toString())) {
+    return lastYear;
+  }
+  return Object.keys(fees).pop();
+};
+
 const update = () => (req, res, next) => {
   const params = {
     model: 'feeWaiver',
@@ -81,7 +89,7 @@ module.exports = () => {
   app.use((req, res, next) => {
     let year = req.query.year;
     if (!year) {
-      year = Object.keys(fees).pop();
+      year = getDefaultYear();
       res.meta.year = year;
       res.response = {};
       return next('router');

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "@asl/constants": {
-      "version": "0.5.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/constants/-/@asl/constants-0.5.0.tgz",
-      "integrity": "sha1-8vWmqKliA9OFgZcKovO+nTWKTuI="
+      "version": "0.7.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/constants/-/@asl/constants-0.7.0.tgz",
+      "integrity": "sha1-dNJiI2O5wYp7oRZ+LyX0mksZInc="
     },
     "@asl/dictionary": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl-internal-api#readme",
   "dependencies": {
-    "@asl/constants": "^0.5.0",
+    "@asl/constants": "^0.7.0",
     "@asl/schema": "^7.32.1",
     "@asl/service": "^7.17.0",
     "express": "^4.16.2",


### PR DESCRIPTION
We have fee data for 2019/20 and 2020/21 both live now. Since we're just beyond the end of the financial year the most likely default year will be the just ended one. Make that default until January, when the soon-to-end year will be default for fees display.