### PR TITLE
Proxy requests to experimental search service if enabled

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,6 +2,7 @@ module.exports = {
   port: process.env.PORT || 8080,
   api: process.env.API_URL,
   workflow: process.env.WORKFLOW_SERVICE,
+  search: process.env.SEARCH_SERVICE,
   auth: {
     realm: process.env.KEYCLOAK_REALM,
     url: process.env.KEYCLOAK_URL,

--- a/lib/api.js
+++ b/lib/api.js
@@ -33,7 +33,14 @@ module.exports = settings => {
     next();
   });
 
-  app.use('/metrics', proxy(`${settings.workflow}/metrics`));
+  app.use((req, res, next) => {
+    if (settings.search && req.get('x-experimental-search') && req.query.search) {
+      req.url = req.url.replace('/search', '/search-experimental');
+    }
+    next();
+  });
+
+  app.use('/search-experimental', proxy(`${settings.search}`));
 
   app.use('/reports', reports());
 


### PR DESCRIPTION
If the server is configured with a search service, and the request has it enabled then proxy to the search service instead of suing DB search.