### PR TITLE
Wrap all the routers mounted onto `/tasks` in a single parent router.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -7,9 +7,7 @@ const user = require('./middleware/user');
 const profile = require('./routers/profile');
 const billing = require('./routers/billing');
 const asruEstablishment = require('./routers/asru-establishment');
-const taskDeadlinePassed = require('./routers/task-deadline-passed');
-const taskExtend = require('./routers/task-extend');
-const taskExemption = require('./routers/task-exemption');
+const tasks = require('./routers/tasks');
 const project = require('./routers/project');
 const projectVersion = require('./routers/project-version');
 const establishment = require('./routers/establishment');
@@ -46,11 +44,7 @@ module.exports = settings => {
 
   app.use('/establishment', establishment());
 
-  app.use('/tasks/deadline-passed', taskDeadlinePassed());
-
-  app.use('/tasks/:taskId/extend', taskExtend());
-
-  app.use('/tasks/:taskId/exemption', taskExemption());
+  app.use('/tasks', tasks());
 
   app.use('/project', project());
 

--- a/lib/routers/tasks/deadline-passed.js
+++ b/lib/routers/tasks/deadline-passed.js
@@ -13,8 +13,7 @@ module.exports = () => {
       .then(response => {
         res.response = response.json.data;
         res.meta = response.json.meta;
-        // don't fall through to the routes below as they will capture 'deadline-passed' as ':taskId'
-        return next('router');
+        next();
       })
       .catch(next);
   });

--- a/lib/routers/tasks/exemption.js
+++ b/lib/routers/tasks/exemption.js
@@ -1,16 +1,11 @@
 const { Router } = require('express');
-const isUUID = require('uuid-validate');
-const { NotFoundError, UnauthorisedError } = require('@asl/service/errors');
+const { UnauthorisedError } = require('@asl/service/errors');
 
 module.exports = () => {
   const router = Router({ mergeParams: true });
 
   router.put('/', (req, res, next) => {
     const taskId = req.params.taskId;
-
-    if (!isUUID(taskId)) {
-      throw new NotFoundError();
-    }
 
     if (!req.user.profile.asruUser || !req.user.profile.asruSupport) {
       throw new UnauthorisedError();

--- a/lib/routers/tasks/extend.js
+++ b/lib/routers/tasks/extend.js
@@ -1,16 +1,11 @@
 const { Router } = require('express');
-const isUUID = require('uuid-validate');
-const { NotFoundError, UnauthorisedError } = require('@asl/service/errors');
+const { UnauthorisedError } = require('@asl/service/errors');
 
 module.exports = () => {
   const router = Router({ mergeParams: true });
 
   router.put('/', (req, res, next) => {
     const taskId = req.params.taskId;
-
-    if (!isUUID(taskId)) {
-      throw new NotFoundError();
-    }
 
     if (!req.user.profile.asruInspector) {
       throw new UnauthorisedError();

--- a/lib/routers/tasks/index.js
+++ b/lib/routers/tasks/index.js
@@ -1,0 +1,28 @@
+const { Router } = require('express');
+const isUUID = require('uuid-validate');
+const { NotFoundError } = require('@asl/service/errors');
+
+const deadline = require('./deadline-passed');
+const extend = require('./extend');
+const exemption = require('./exemption');
+
+module.exports = settings => {
+  const app = Router({ mergeParams: true });
+
+  app.param('taskId', (req, res, next, taskId) => {
+    if (!isUUID(taskId)) {
+      throw new NotFoundError();
+    }
+    next();
+  });
+
+  app.use('/deadline-passed', deadline());
+  // skip remaining routers
+  app.use('/deadline-passed', (req, res, next) => next('route'));
+
+  app.use('/:taskId/extend', extend());
+
+  app.use('/:taskId/exemption', exemption());
+
+  return app;
+};


### PR DESCRIPTION
This allows common functionality to be abstracted, and more fine-grained control over the routing.