### PR TITLE
Remove field whitelist

### DIFF
--- a/lib/routers/establishment.js
+++ b/lib/routers/establishment.js
@@ -107,8 +107,7 @@ module.exports = () => {
   );
 
   router.put('/:id',
-    permissions('establishment.updateConditions'),
-    whitelist(req => req.models.Establishment.unlicensed),
+    permissions('establishment.update'),
     update('update')
   );
 


### PR DESCRIPTION
This can't whitelist unlicensed fields because it is also used to update licensed fields.