### PR TITLE
Don't allow profile merge if either profile has open tasks

### DIFF
--- a/lib/routers/profile.js
+++ b/lib/routers/profile.js
@@ -100,9 +100,14 @@ module.exports = () => {
           if (profile.asruUser) {
             throw new BadRequestError('Cannot merge profiles with an ASRU user');
           }
-          return profile;
         })
-        .then(profile => req.workflow.profileTasks(req.profile.id))
+        .then(() => req.workflow.profileTasks(req.profile.id))
+        .then(response => {
+          if (response.json.data.length) {
+            throw new BadRequestError('Cannot merge profile with open tasks.');
+          }
+        })
+        .then(() => req.workflow.profileTasks(id))
         .then(response => {
           if (response.json.data.length) {
             throw new BadRequestError('Cannot merge profile with open tasks.');


### PR DESCRIPTION
Currently we check one of the profiles involved in a merge for open tasks, but not the other.

This prevents carrying out a profile merge if _either_ profile has any related open tasks.