### PR TITLE
Task metrics reports are now generated via exports table

### DIFF
--- a/lib/routers/reports/task-metrics.js
+++ b/lib/routers/reports/task-metrics.js
@@ -1,40 +1,27 @@
 const { Router } = require('express');
-const moment = require('moment');
-const { BadRequestError } = require('@asl/service/errors');
-const metrics = require('../../middleware/metrics');
 
 module.exports = settings => {
   const router = Router({ mergeParams: true });
 
-  router.use(metrics(settings));
+  router.use('/', (req, res, next) => {
+    const { Export } = req.models;
+    return Export.query()
+      .where({ type: 'task-metrics', ready: true })
+      .orderBy('createdAt', 'desc')
+      .then(result => {
+        res.response = result;
+      })
+      .then(() => next())
+      .catch(next);
+  });
 
-  router.get('/', (req, res, next) => {
-    const { year, month } = req.query;
-
-    if (!year) {
-      throw new BadRequestError('valid year must be provided');
-    }
-
-    if (!month) {
-      throw new BadRequestError('valid month must be provided');
-    }
-
-    const start = moment(`${year}-${month}-01`);
-
-    if (!start.isValid() || start.isBefore('2021-12-01')) {
-      throw new BadRequestError('reports prior to internal deadlines (Dec 2021) are invalid');
-    }
-
-    const end = start.clone().endOf('month');
-
-    const metricsParams = {
-      start: start.format('YYYY-MM-DD'),
-      end: end.format('YYYY-MM-DD')
-    };
-
-    return req.metrics('/reports/internal-deadlines', { stream: false, query: metricsParams })
-      .then(data => {
-        res.response = data.filter(Boolean);
+  router.get('/:exportId', (req, res, next) => {
+    const { Export } = req.models;
+    return Export.query()
+      .findById(req.params.exportId)
+      .where({ type: 'task-metrics', ready: true })
+      .then(result => {
+        res.response = result;
       })
       .then(() => next())
       .catch(next);

--- a/lib/routers/rops/index.js
+++ b/lib/routers/rops/index.js
@@ -129,7 +129,7 @@ module.exports = () => {
     const { Export } = req.models;
     return Export.query()
       .withGraphFetched('profile')
-      .where({ key: req.year })
+      .where({ type: 'rops', key: req.year })
       .orderBy('createdAt', 'desc')
       .then(result => {
         req.exports = result;


### PR DESCRIPTION
Previously we were hitting the metrics service directly to demo the internal deadlines report.

This is now done monthly via the data-exports service and available reports will be listed in the exports table.