### PR TITLE
Fix result counts in billing establishment list

### DIFF
--- a/lib/routers/billing.js
+++ b/lib/routers/billing.js
@@ -154,11 +154,12 @@ module.exports = settings => {
         res.meta.cache = result.cache;
         res.meta.total = result.length;
         if (filter) {
-          return result.filter(establishment => establishment.name.includes(filter));
+          return result.filter(establishment => establishment.name.toLowerCase().includes(filter.toLowerCase()));
         }
         return result;
       })
       .then((result) => {
+        res.meta.count = result.length;
         return result.map(est => {
           return {
             ...est,
@@ -173,7 +174,6 @@ module.exports = settings => {
       })
       .then(result => result.slice(offset, offset + limit))
       .then(result => {
-        res.meta.count = result.length;
         res.response = result;
       })
       .then(() => next())


### PR DESCRIPTION
The count returned should be the count _before_ pagination, and not after.

This fixes a bug where only the first 30 establishments were shown when there were more than 30, and no additional pages were available.

Also normalise case when searching on establishment name so sers don't have to input the case exactly.