### PR TITLE
Update dependency asl-constants from 2.1.1 to 2.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "asl-internal-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "asl-internal-api",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "^10.18.0",
         "@asl/service": "^10.3.0",
-        "@ukhomeoffice/asl-constants": "2.1.1",
+        "@ukhomeoffice/asl-constants": "2.1.4",
         "express": "^4.18.2",
         "http-proxy": "^1.18.1",
         "into-stream": "^4.0.0",
@@ -2024,9 +2024,9 @@
       }
     },
     "node_modules/@ukhomeoffice/asl-constants": {
-      "version": "2.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.1.1/a5a3561d5eb9f62d4ac3f832152e1970d9985e74",
-      "integrity": "sha512-c9JnXRJXHGXC3gM7pJSFZ70JRqiD7O4Md346udz+yP51ggfsum5hYLNSTAgkCSCI9DmSe3q9xnLIJB6nmMD7Bg==",
+      "version": "2.1.4",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.1.4/e2ea42d12a3bc30759d85c6915cad38a8a4889d1",
+      "integrity": "sha512-rfHpSzSqZ4VoyUuNH84Ih8NkA17XwWR5BQeSuPx1/H5/YHTAhaVV7KNOwx3BCFmUehEF9QqCzDf8az5Qqw5FbA==",
       "license": "MIT"
     },
     "node_modules/@ukhomeoffice/asl-dictionary": {
@@ -14421,9 +14421,9 @@
       }
     },
     "@ukhomeoffice/asl-constants": {
-      "version": "2.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.1.1/a5a3561d5eb9f62d4ac3f832152e1970d9985e74",
-      "integrity": "sha512-c9JnXRJXHGXC3gM7pJSFZ70JRqiD7O4Md346udz+yP51ggfsum5hYLNSTAgkCSCI9DmSe3q9xnLIJB6nmMD7Bg=="
+      "version": "2.1.4",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.1.4/e2ea42d12a3bc30759d85c6915cad38a8a4889d1",
+      "integrity": "sha512-rfHpSzSqZ4VoyUuNH84Ih8NkA17XwWR5BQeSuPx1/H5/YHTAhaVV7KNOwx3BCFmUehEF9QqCzDf8az5Qqw5FbA=="
     },
     "@ukhomeoffice/asl-dictionary": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asl-internal-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   "dependencies": {
     "@asl/schema": "^10.18.0",
     "@asl/service": "^10.3.0",
-    "@ukhomeoffice/asl-constants": "2.1.1",
+    "@ukhomeoffice/asl-constants": "2.1.4",
     "express": "^4.18.2",
     "http-proxy": "^1.18.1",
     "into-stream": "^4.0.0",


### PR DESCRIPTION
Update dependency asl-constants from 2.1.1 to 2.1.4; Update asl-internal-api version from 1.0.1 to 1.0.2